### PR TITLE
fix out-of-bounds memory error

### DIFF
--- a/kernel/ktf_map.c
+++ b/kernel/ktf_map.c
@@ -29,7 +29,7 @@ void ktf_map_init(struct ktf_map *map, ktf_map_elem_comparefn elem_comparefn,
 /* returns 0 upon success or -ENOMEM if key got truncated */
 int ktf_map_elem_init(struct ktf_map_elem *elem, const char *key)
 {
-	memcpy(elem->key, key, KTF_MAX_KEY);
+	strncpy(elem->key, key, KTF_MAX_KEY);
 	elem->map = NULL;
 	kref_init(&elem->refcount);
 	return 0;


### PR DESCRIPTION
error on `KTF_CONTEXT_ADD` with short name

KASAN output:
```
[  +0.002124] BUG: KASAN: global-out-of-bounds in ktf_map_elem_init+0x94/0x160 [ktf]
[  +0.001490] Read of size 64 at addr ffffffffc0419040 by task insmod/2236
```
