### PR TITLE
Fixes to make KTF compile and run properly on kernels >= 5.8 and distributions with Python 3 as default

### DIFF
--- a/kernel/Makefile.in
+++ b/kernel/Makefile.in
@@ -13,7 +13,7 @@ obj-m := ktf.o
 -include ktf_gen.mk
 
 ktf-y := ktf_context.o ktf_nl.o ktf_map.o ktf_test.o ktf_debugfs.o ktf_cov.o \
-	 ktf_override.o ktf_netctx.o
+	 ktf_override.o ktf_netctx.o ktf_kallsyms.o
 
 KDIR   := @KDIR@
 PWD    := $(shell pwd)

--- a/kernel/ktf_cov.c
+++ b/kernel/ktf_cov.c
@@ -5,7 +5,6 @@
  *
  * ktf_cov.c: Code coverage support implementation for KTF.
  */
-#include <linux/kallsyms.h>
 #include <linux/debugfs.h>
 #include <linux/mm.h>
 #include <linux/module.h>
@@ -18,6 +17,7 @@
 #include "ktf_map.h"
 #include "ktf_cov.h"
 #include "ktf_compat.h"
+#include "ktf_kallsyms.h"
 
 /* It may seem odd that we use a refcnt field in ktf_cov_entry structures
  * in addition to using krefcount management via the ktf_map.  The reasoning
@@ -566,7 +566,7 @@ int ktf_cov_enable(const char *name, unsigned int opts)
 		register_kretprobe_size =
 			ktf_symbol_size((unsigned long)register_kretprobe);
 		mutex_lock(&module_mutex);
-		kallsyms_on_each_symbol(ktf_cov_init_symbol, cov);
+		ki.kallsyms_on_each_symbol(ktf_cov_init_symbol, cov);
 		mutex_unlock(&module_mutex);
 	} else {
 		ktf_map_for_each_entry(entry, &cov_entry_map, kmap) {

--- a/kernel/ktf_kallsyms.c
+++ b/kernel/ktf_kallsyms.c
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2021 Knut Omang <knuto@ifi.uio.no>
+ *
+ * ktf_kallsyms.c: Access to kernel private symbols for bootstrapping
+ *
+ * With workaround to bootstrap access to kallsyms_lookup_name itself
+ * after it was made inaccessible to modules in
+ *   commit 'kallsyms: unexport kallsyms_lookup_name() and kallsyms_on_each_symbol()'
+ * Inspired by https://github.com/zizzu0/LinuxKernelModules
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/kprobes.h>
+#include <linux/kallsyms.h>
+#include "ktf.h"
+#include "ktf_kallsyms.h"
+
+struct ktf_kernel_internals ki;
+
+#if (KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE)
+
+static off_t ktf_kallsyms_offset = 0;
+static unsigned long kallsyms_lookup_name_probe_entry = 0;
+
+KTF_ENTRY_PROBE(kallsyms_lookup_name, aln_init)
+{
+	kallsyms_lookup_name_probe_entry = instruction_pointer(regs);
+	KTF_ENTRY_PROBE_RETURN(0);
+}
+
+KTF_ENTRY_PROBE(kfree, verif)
+{
+	ktf_kallsyms_offset = (off_t)instruction_pointer(regs) - (off_t)kfree;
+	KTF_ENTRY_PROBE_RETURN(0);
+}
+
+int ktf_kallsyms_bootstrap(void)
+{
+	/* Register a probe on kallsyms_lookup_name to get the address where the probe entered: */
+	int stat = KTF_REGISTER_ENTRY_PROBE(kallsyms_lookup_name, aln_init);
+	if (stat)
+		goto init_failed;
+
+	/* Determine the offset from the function the probe is on to the
+	 * instruction pointer when we enter the probe by using a probe on a
+	 * known symbol: kfree() can be safely called with 0 without side effects
+	 * and is unlikely to change definition in a future kernel.
+	 *
+	 * By registering a second probe we also implicitly trigger a call to the first
+	 * probe since kallsym_lookup_name is used internally to find the address of
+	 * the function to probe, here kfree:
+	 */
+	stat = KTF_REGISTER_ENTRY_PROBE(kfree, verif);
+	if (stat) {
+		KTF_UNREGISTER_ENTRY_PROBE(kallsyms_lookup_name, aln_init);
+		goto init_failed;
+	}
+
+	/* Now make sure kfree() has been called at least once with the probe:
+	 * (it likely has been called several times already but that's no big deal)
+	 */
+	kfree(0);
+	KTF_UNREGISTER_ENTRY_PROBE(kfree, verif);
+	KTF_UNREGISTER_ENTRY_PROBE(kallsyms_lookup_name, aln_init);
+
+	ki.kallsyms_lookup_name = (void*)(kallsyms_lookup_name_probe_entry - ktf_kallsyms_offset);
+	if (ki.kallsyms_lookup_name) {
+		tlog(T_DEBUG, "Got kallsyms_lookup_name at %p", ki.kallsyms_lookup_name);
+	} else {
+		terr("Unable to access the address of 'kallsyms_lookup_name'");
+		return -ENODEV;
+	}
+	return 0;
+init_failed:
+	terr("Failed to set up kallsyms access");
+	return stat;
+}
+#endif
+
+/* Support for looking up kernel/module internal symbols to enable testing.
+ * A NULL mod means either we want the kernel-internal symbol or don't care
+ * which module the symbol is in.
+ */
+void *ktf_find_symbol(const char *mod, const char *sym)
+{
+	char sm[200];
+	const char *symref;
+	unsigned long addr = 0;
+
+	if (mod) {
+		sprintf(sm, "%s:%s", mod, sym);
+		symref = sm;
+	} else {
+		/* Try for kernel-internal symbol first; fall back to modules
+		 * if that fails.
+		 */
+		symref = sym;
+		addr = ki.kallsyms_lookup_name(symref);
+	}
+	if (!addr)
+		addr = ki.module_kallsyms_lookup_name(symref);
+	if (addr) {
+		tlog(T_DEBUG, "Found %s at %0lx", sym, addr);
+	} else {
+#ifndef CONFIG_KALLSYMS_ALL
+		twarn("CONFIG_KALLSYMS_ALL is not set, so non-exported symbols are not available");
+#endif
+		tlog(T_INFO, "Fatal error: %s not found", sym);
+		return NULL;
+	}
+	return (void *)addr;
+}
+EXPORT_SYMBOL(ktf_find_symbol);
+
+unsigned long ktf_symbol_size(unsigned long addr)
+{
+	unsigned long size = 0;
+
+	(void)ki.kallsyms_lookup_size_offset(addr, &size, NULL);
+
+	return size;
+}
+EXPORT_SYMBOL(ktf_symbol_size);
+
+int ktf_kallsyms_init(void)
+{
+	char *ks;
+#if (KERNEL_VERSION(5, 8, 0) < LINUX_VERSION_CODE)
+	int stat = ktf_kallsyms_bootstrap();
+
+	if (stat)
+		return stat;
+#else
+	ki.kallsyms_lookup_name = kallsyms_lookup_name;
+	ki.kallsyms_on_each_symbol = kallsyms_on_each_symbol;
+#endif
+	/* We rely on being able to resolve this symbol for looking up module
+	 * specific internal symbols (multiple modules may define the same symbol):
+	 */
+	ks = "module_kallsyms_lookup_name";
+	ki.module_kallsyms_lookup_name = (void *)ki.kallsyms_lookup_name(ks);
+	if (!ki.module_kallsyms_lookup_name) {
+		terr("Unable to look up \"%s\" in kallsyms - maybe interface has changed?",
+		     ks);
+		return -EINVAL;
+	}
+	ks = "kallsyms_on_each_symbol";
+	ki.kallsyms_on_each_symbol = (void *)ki.kallsyms_lookup_name(ks);
+	if (!ki.kallsyms_on_each_symbol) {
+		terr("Unable to look up \"%s\" in kallsyms - maybe interface has changed?",
+		     ks);
+		return -EINVAL;
+	}
+	ks = "kallsyms_lookup_size_offset";
+	ki.kallsyms_lookup_size_offset = (void *)ki.kallsyms_lookup_name(ks);
+	if (!ki.kallsyms_lookup_size_offset) {
+		terr("Unable to look up \"%s\" in kallsyms - maybe interface has changed?",
+		     ks);
+		return -EINVAL;
+	}
+	return 0;
+}

--- a/kernel/ktf_kallsyms.h
+++ b/kernel/ktf_kallsyms.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2021 Knut Omang <knuto@ifi.uio.no>
+ *
+ * ktf_kallsyms.h: Access to kernel private symbols
+ */
+
+#ifndef _KTF_KALLSYMS_H
+#define _KTF_KALLSYMS_H
+#include <linux/version.h>
+
+int ktf_kallsyms_init(void);
+
+struct ktf_kernel_internals {
+	/* From kallsyms.h: In kernels beyond 5.8 these are not exported to modules */
+	unsigned long (*kallsyms_lookup_name)(const char *name);
+	int (*kallsyms_on_each_symbol)(int (*fn)(void *, const char *, struct module *,
+						 unsigned long),
+				       void *data);
+	/* From module.h: Look up a module symbol - supports syntax module:name */
+	unsigned long (*module_kallsyms_lookup_name)(const char *name);
+	/* From kallsyms.h: Look up a symbol w/size and offset */
+	unsigned long (*kallsyms_lookup_size_offset)(unsigned long addr,
+						     unsigned long *symbolsize,
+						     unsigned long *offset);
+};
+
+extern struct ktf_kernel_internals ki;
+#endif

--- a/kernel/ktf_nl.c
+++ b/kernel/ktf_nl.c
@@ -300,7 +300,7 @@ static int ktf_run_func(struct sk_buff *skb, const char *ctxname,
 	int tn = 0;
 
 	if (!testset) {
-		tlog(T_INFO, "No such testset \"%s\"\n", setname);
+		tlog(T_INFO, "No such testset \"%s\"", setname);
 		return -EFAULT;
 	}
 
@@ -367,7 +367,7 @@ static int ktf_run(struct sk_buff *skb, struct genl_info *info)
 		oob_data_sz = nla_len(data_attr);
 	}
 
-	tlog(T_DEBUG, "Request for testset %s, test %s\n", setname, testname);
+	tlog(T_DEBUG, "Request for testset %s, test %s", setname, testname);
 
 	/* Start building a response */
 	resp_skb = nlmsg_new(NLMSG_DEFAULT_SIZE, GFP_KERNEL);
@@ -391,7 +391,7 @@ static int ktf_run(struct sk_buff *skb, struct genl_info *info)
 
 	retval = genlmsg_reply(resp_skb, info);
 	if (!retval)
-		tlog(T_DEBUG, "Sent reply for test %s.%s\n", setname, testname);
+		tlog(T_DEBUG, "Sent reply for test %s.%s", setname, testname);
 	else
 		twarn("Failed to send reply for test %s.%s - value %d",
 		      setname, testname, retval);
@@ -439,7 +439,7 @@ static int ktf_cov_cmd(struct sk_buff *skb,
 	if (!resp_skb)
 		return -ENOMEM;
 
-	tlog(T_DEBUG, "%s coverage for %s\n", cmd, module);
+	tlog(T_DEBUG, "%s coverage for %s", cmd, module);
 	if (enable)
 		retval = ktf_cov_enable(module, opts);
 	else
@@ -458,7 +458,7 @@ static int ktf_cov_cmd(struct sk_buff *skb,
 
 	retval = genlmsg_reply(resp_skb, info);
 	if (!retval)
-		tlog(T_DEBUG, "Sent reply for %s module %s\n",
+		tlog(T_DEBUG, "Sent reply for %s module %s",
 		     cmd, module);
 	else
 		twarn("Failed to send reply for %s module %s - value %d",

--- a/kernel/ktf_test.c
+++ b/kernel/ktf_test.c
@@ -127,7 +127,7 @@ static struct ktf_case *ktf_case_create(const char *name)
 		return NULL;
 	}
 	ktf_debugfs_create_testset(tc);
-	tlog(T_DEBUG, "ktf: Added test set %s\n", name);
+	tlog(T_DEBUG, "ktf: Added test set %s", name);
 	return tc;
 }
 
@@ -271,7 +271,7 @@ void  _ktf_add_test(struct __test_desc td, struct ktf_handle *th,
 
 	ktf_debugfs_create_test(t);
 
-	tlog(T_LIST, "Added test \"%s.%s\" start = %d, end = %d\n",
+	tlog(T_LIST, "Added test \"%s.%s\" start = %d, end = %d",
 	     td.tclass, td.name, start, end);
 
 	/* Now since we no longer reference tc/t outside of global map of test

--- a/scripts/resolve
+++ b/scripts/resolve
@@ -10,10 +10,10 @@
 # (See the documentation for KTF for details)
 #
 
-import os, sys, re, shutil, string, ConfigParser
+import os, sys, re, shutil, string
 
 def usage():
-    print "Usage: resolve symbolfile outputfile"
+    print("Usage: resolve symbolfile outputfile")
     exit(0)
 
 class ResolveError(Exception):
@@ -91,9 +91,9 @@ class Module:
                 s_count = s_count + 1
 
             if s_count != len(symbols):
-                print " ** Warning: File %s: Found %d definitions from %d symbols!" % \
-                    (hf, s_count, len(symbols))
-                print " ** - please check/fix output manually!"
+                print(" ** Warning: File %s: Found %d definitions from %d symbols!" % \
+                    (hf, s_count, len(symbols)))
+                print(" ** - please check/fix output manually!")
 
     # Output functions:
     def write_funcs(self, file):
@@ -154,17 +154,17 @@ try:
                 module.SetHeader(header)
             else:
                 raise ResolveError("While parsing %s: Unknown directive \"%s\"" % (symfile, cmd))
-            #print "%s set to %s" % (cmd, value)
+            #print("%s set to %s" % (cmd, value))
             continue
         match = re.match(r"\s*(\w+)\s*", line)
         if match != None:
             s = match.group(1)
             module.AddSymbol(s)
 except ResolveError as e:
-    print e.value;
+    print(e.value)
     exit(1)
 except:
-    print "Unable to open config file \"%s\"" % symfile
+    print("Unable to open config file \"%s\"" % symfile)
     exit(1)
 
 for m in all_modules:
@@ -173,7 +173,7 @@ for m in all_modules:
 try:
     output = open(outputfile, "w")
 except:
-    print "Failed to open output header file \"%s\"" % outputfile
+    print("Failed to open output header file \"%s\"" % outputfile)
 output.write('#ifndef _KTF_RESOLVE_H\n#define _KTF_RESOLVE_H\n')
 output.write('#include "ktf.h"\n\nstruct ktf_syms {\n')
 

--- a/selftest/self.c
+++ b/selftest/self.c
@@ -291,7 +291,7 @@ TEST(selftest, dummy)
 
 TEST(selftest, wrongversion)
 {
-	tlog(T_INFO, "This test should never have run - wrong version\n!!!");
+	tlog(T_INFO, "This test should never have run - wrong version!!!");
 	EXPECT_TRUE(false);
 }
 
@@ -331,7 +331,7 @@ KTF_ENTRY_PROBE(probeargtest, probeargtesthandler)
 
 noinline void probeargtest(int arg0, int arg1)
 {
-	tlog(T_INFO, "got args %d, %d\n", arg0, arg1);
+	tlog(T_INFO, "got args %d, %d", arg0, arg1);
 }
 
 TEST(selftest, probeentry)
@@ -470,7 +470,7 @@ TEST(selftest, cov)
 
 	ASSERT_ADDR_NE(NULL, c);
 
-	tlog(T_INFO, "Allocated cache %p : w/object size %u\n", c, kmem_cache_size(c));
+	tlog(T_INFO, "Allocated cache %p : w/object size %u", c, kmem_cache_size(c));
 	ASSERT_INT_EQ(0, ktf_cov_enable((THIS_MODULE)->name, KTF_COV_OPT_MEM));
 
 	e = ktf_cov_entry_find((unsigned long)cov_counted, 0);


### PR DESCRIPTION
See commit log for details