### PR TITLE
ktf_compat: remove outer wrapper define

### DIFF
--- a/kernel/ktf_compat.h
+++ b/kernel/ktf_compat.h
@@ -1,4 +1,3 @@
-#if (KERNEL_VERSION(5, 2, 0) > LINUX_VERSION_CODE)
 // SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
@@ -6,7 +5,6 @@
  *
  * ktf_compat.h: Backward compatibility support
  */
-
 
 /*
  * At any time we want to keep KTF code and users
@@ -57,5 +55,4 @@ static inline unsigned int stack_trace_save(unsigned long *store, unsigned int s
 #define nla_strscpy nla_strlcpy
 #endif
 
-#endif
 #endif


### PR DESCRIPTION
This define was there to make it easy to
completely eliminate ktf_compat.h for kernels that do not
need any bw.comp fixes, but as the need for this commit shows
it is rather error prone as it had not been updated when
more bw.comp fixes became necessary.

Just eliminate it and let a few blank lines be compiled
even for new kernels.

Change-Id: I05522a00f49c33145a6d6699cd1fb88ed90b2d56
Reported-by: Batiste Heron <github:Mantra84>
Signed-off-by: Knut Omang <knuto@ifi.uio.no>