### PR TITLE
Makefile: add modules_install target

### DIFF
--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -26,6 +26,10 @@ EXTRASYMS := KBUILD_EXTRA_SYMBOLS="$(KTF_BDIR)/Module.symvers"
 
 module:
 	$(MAKE) -C $(KDIR) M=$(PWD) $(EXTRASYMS) modules
+
+modules_install:
+	$(MAKE) -C $(KDIR) M=$(PWD) $(EXTRASYMS) modules_install
+	
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
 

--- a/kernel/Makefile.in
+++ b/kernel/Makefile.in
@@ -20,6 +20,10 @@ PWD    := $(shell pwd)
 
 module:
 	$(MAKE) -C $(KDIR) M=$(PWD)
+
+modules_install:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
+
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
 

--- a/selftest/Makefile.in
+++ b/selftest/Makefile.in
@@ -26,6 +26,10 @@ EXTRASYMS := KBUILD_EXTRA_SYMBOLS="$(KTF_BDIR)/Module.symvers"
 
 module:
 	$(MAKE) -C $(KDIR) M=$(PWD) $(EXTRASYMS) modules
+
+modules_install:
+	$(MAKE) -C $(KDIR) M=$(PWD) $(EXTRASYMS) modules_install
+
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
 


### PR DESCRIPTION
add modules_install target in makefile.in for simpler module installation.

Signed-off-by: Batiste HERON <batiste.heron@sigfox.com>