### PR TITLE
Fix: Corrected missing subdirs replacement

### DIFF
--- a/scripts/ktfnew
+++ b/scripts/ktfnew
@@ -121,7 +121,7 @@ KDIR   := @KDIR@
 PWD    := $(shell pwd)\n
 EXTRASYMS := KBUILD_EXTRA_SYMBOLS="$(KTF_BDIR)/Module.symvers"\n
 module:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) $(EXTRASYMS) modules\n
+	$(MAKE) -C $(KDIR) M=$(PWD) $(EXTRASYMS) modules\n
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean\n
 check: all


### PR DESCRIPTION
In d7b4a61d61fe6a3079167af61688d603b03b4287 a correction in the ktfnew script is missing.

Without this PR a newly created project can't be build.